### PR TITLE
Improve mobile responsive design

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -35,13 +35,13 @@ body {
 .container {
   max-width: 800px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 1.5rem;
   position: relative;
   z-index: 1;
 }
 
 header {
-  padding: 4rem 0;
+  padding: 1.5rem 0 1rem;
 }
 
 header h1, header .tagline {
@@ -49,17 +49,17 @@ header h1, header .tagline {
 }
 
 h1 {
-  font-size: 4rem;
+  font-size: 3rem;
   font-weight: 900;
   background: linear-gradient(90deg, var(--pink), var(--yellow), var(--cyan));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.25rem;
 }
 
 .tagline {
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   color: var(--purple);
   opacity: 0.9;
 }
@@ -67,15 +67,15 @@ h1 {
 .section {
   background: rgba(255, 255, 255, 0.05);
   border-radius: 1rem;
-  padding: 2rem;
-  margin-bottom: 2rem;
+  padding: 1.25rem;
+  margin-bottom: 1rem;
   border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .section h2 {
   color: var(--yellow);
-  margin-bottom: 1rem;
-  font-size: 1.5rem;
+  margin-bottom: 0.75rem;
+  font-size: 1.25rem;
 }
 
 .section p {
@@ -120,18 +120,21 @@ h1 {
 
 .apps-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 0.75rem;
 }
 
 .app-card {
   background: rgba(255, 255, 255, 0.08);
   border-radius: 0.75rem;
-  padding: 1.5rem;
+  padding: 1rem;
   text-decoration: none;
   color: var(--light);
   transition: transform 0.2s, background 0.2s;
   border: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  flex-direction: column;
+  min-height: 100px;
 }
 
 .app-card:hover {
@@ -142,11 +145,17 @@ h1 {
 .app-card h3 {
   color: var(--cyan);
   margin-bottom: 0.5rem;
+  font-size: 1rem;
 }
 
 .app-card p {
-  font-size: 0.875rem;
+  font-size: 0.8rem;
   opacity: 0.8;
+  flex: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .empty-state {
@@ -158,7 +167,7 @@ h1 {
 
 footer {
   text-align: center;
-  padding: 2rem;
+  padding: 1rem;
   opacity: 0.6;
   font-size: 0.875rem;
 }
@@ -319,9 +328,9 @@ footer a {
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-bottom: none;
   border-radius: 0.5rem 0.5rem 0 0;
-  padding: 0.75rem 1.5rem;
+  padding: 0.6rem 1rem;
   color: var(--light);
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-weight: 500;
   cursor: pointer;
   opacity: 0.6;
@@ -346,4 +355,46 @@ footer a {
 
 .tab-content.active {
   display: block;
+}
+
+/* Mobile responsive */
+@media (max-width: 480px) {
+  .container {
+    padding: 1rem;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+  }
+
+  .tagline {
+    font-size: 1rem;
+  }
+
+  .section {
+    padding: 1rem;
+  }
+
+  .apps-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .app-card {
+    min-height: 90px;
+  }
+
+  .login-btn {
+    padding: 0.4rem 0.75rem;
+    font-size: 0.875rem;
+  }
+
+  .user-info {
+    gap: 0.5rem;
+    font-size: 0.875rem;
+  }
+
+  .avatar {
+    width: 28px;
+    height: 28px;
+  }
 }


### PR DESCRIPTION
- Reduce header padding from 4rem to 1.5rem
- Reduce container/section padding for tighter layout
- Make app cards equal height with line clamping
- Add mobile media query for screens under 480px
- Reduce font sizes throughout for better mobile fit